### PR TITLE
Better regex for filtering and preventing rate limit

### DIFF
--- a/gift.js
+++ b/gift.js
@@ -1,4 +1,4 @@
-const regex_str = /(?:discord\.gift|(?:discord|discordapp)\.com\/gifts)\/([A-Za-z0-9]+)/g
+const regex_str = /(?:discord\.gift|(?:discord|discordapp)\.com\/gifts)\/(?=.*[A-Za-z][0-9]+).{16,24}$/g
 const config = require("./config");
 const http_client = new (require("./http"))("discord.com");
 let db;

--- a/gift.js
+++ b/gift.js
@@ -1,4 +1,4 @@
-const regex_str = /(?:discord\.gift|(?:discord|discordapp)\.com\/gifts)\/(?=.*[A-Za-z][0-9]+).{16,24}$/g
+const regex_str = /(?:discord\.gift|(?:discord|discordapp)\.com\/gifts)\/(?=.*[A-Z]+[a-z]+[0-9]+).{16,24}$/g
 const config = require("./config");
 const http_client = new (require("./http"))("discord.com");
 let db;


### PR DESCRIPTION
Also I'd suggest using global quantifiers cause they make the regex indexing faster.

Ignores words, requires it to contain at least one capital one small letter and a number,  ignores only numbers and only letters making it unable to get spammed or rate limited by fake/troll/invalid gifts and requires code to be from 16 to 24 characters as 16 chars is the normal discord gift code format and 24 is the xbox gamepass promo nitro format.